### PR TITLE
style: use plain layout

### DIFF
--- a/lib/bangumi-generator.js
+++ b/lib/bangumi-generator.js
@@ -151,7 +151,7 @@ module.exports = /*#__PURE__*/function () {
                 content: contents,
                 permalink: full_url_for(customPath)
               }, config === null || config === void 0 ? void 0 : (_config$type2 = config[type]) === null || _config$type2 === void 0 ? void 0 : _config$type2.extra_options),
-              layout: ['page', 'post']
+              layout: ['page', 'plain']
             });
 
           case 17:


### PR DESCRIPTION
# 适配 [nexmoe](https://github.com/theme-nexmoe/hexo-theme-nexmoe/) 主题的布局风格。

## 最初使用的效果（post布局）如下：
![image](https://user-images.githubusercontent.com/74645100/184294655-14a88623-0d68-4416-885d-344f1d8dda88.png)

---

## 使用 plain 布局的效果如下：
![image](https://user-images.githubusercontent.com/74645100/184294701-6d7817c4-759d-482b-91e8-b20e6645f8f5.png)

---

变化主要是删除了多余的 widget，比如字数统计、发布时间等。
可以发现这些东西都是不需要的，删除后主次更加分明，显示效果更好。
