### PR TITLE
fix: await bangumi item data before filtering

### DIFF
--- a/lib/get-bgm-data.js
+++ b/lib/get-bgm-data.js
@@ -548,27 +548,27 @@ module.exports.getBgmData = function () {
           _context6.next = 2;
           return getItemsId(_objectSpread(_objectSpread({}, options), {}, {
             status: 'wish'
-          })).filter(function (item) {
+          }));
+        case 2:
+          wantWatch = _context6.sent.filter(function (item) {
             return !(skipNsfw && item.nsfw);
           });
-        case 2:
-          wantWatch = _context6.sent;
           _context6.next = 3;
           return getItemsId(_objectSpread(_objectSpread({}, options), {}, {
             status: 'do'
-          })).filter(function (item) {
+          }));
+        case 3:
+          watching = _context6.sent.filter(function (item) {
             return !(skipNsfw && item.nsfw);
           });
-        case 3:
-          watching = _context6.sent;
           _context6.next = 4;
           return getItemsId(_objectSpread(_objectSpread({}, options), {}, {
             status: 'collect'
-          })).filter(function (item) {
+          }));
+        case 4:
+          watched = _context6.sent.filter(function (item) {
             return !(skipNsfw && item.nsfw);
           });
-        case 4:
-          watched = _context6.sent;
           endTime = new Date().getTime();
           log.info("".concat(wantWatch.length + watching.length + watched.length, " ").concat(type, "s have been loaded in ").concat(endTime - startTime, " ms"));
           bangumis = {

--- a/src/lib/get-bgm-data.js
+++ b/src/lib/get-bgm-data.js
@@ -534,18 +534,18 @@ module.exports.getBgmData = async function getBgmData({
       skipNsfw
     };
     // 获取三种状态的数据
-    const wantWatch = await getItemsId({
+    const wantWatch = (await getItemsId({
       ...options,
       status: 'wish'
-    }).filter((item) => !(skipNsfw && item.nsfw));
-    const watching = await getItemsId({
+    })).filter((item) => !(skipNsfw && item.nsfw));
+    const watching = (await getItemsId({
       ...options,
       status: 'do'
-    }).filter((item) => !(skipNsfw && item.nsfw));
-    const watched = await getItemsId({
+    })).filter((item) => !(skipNsfw && item.nsfw));
+    const watched = (await getItemsId({
       ...options,
       status: 'collect'
-    }).filter((item) => !(skipNsfw && item.nsfw));
+    })).filter((item) => !(skipNsfw && item.nsfw));
 
     const endTime = new Date().getTime();
     log.info(`${wantWatch.length + watching.length + watched.length} ${type}s have been loaded in ${endTime - startTime} ms`);


### PR DESCRIPTION
Fix getItemsId(...).filter is not a function by applying filters
after getItemsId resolves. Update both source and compiled output so
wish, watching, and collected Bangumi lists are filtered after the
async fetch returns an array.