### PR TITLE
修复逻辑赋值错误

### DIFF
--- a/lib/bangumi-generator.js
+++ b/lib/bangumi-generator.js
@@ -107,7 +107,7 @@ module.exports = function () {
           _context.next = 2;
           return pug.renderFile(path.join(__dirname, 'templates/bangumi.pug'), {
             quote: config[type].quote,
-            show: config[type].show || 1,
+            show: config[type].show ?? 1,
             metaColor: config[type].metaColor,
             color: config[type].color,
             lazyload: (_config$type$lazyload = config[type].lazyload) !== null && _config$type$lazyload !== void 0 ? _config$type$lazyload : true,


### PR DESCRIPTION
源代码
`show: config[type].show || 1`
||左边如果是0，js会回退并将值设为1，导致默认展示在看列表而不是想看列表
改成`show: config[type].show ?? 1`
即可解决，0可正常生效